### PR TITLE
Add python_requires to setup.py - minimum version 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,4 +36,5 @@ setup(
             "ressenter=ressenter.cli:cli",
         ]
     },
+    python_requires='>=3.8'
 )


### PR DESCRIPTION
Ressenter requires a minimum Python version of 3.8. This PR makes it impossible to install ressenter on earlier Python versions.

I know this because I accidentally installed ressenter with Python 3.6, then nothing worked because Python 3.6 doesn't support assignment expressions 🙂 